### PR TITLE
add rewards calculator to SelfHosted Worker option under Create Worker

### DIFF
--- a/packages/react-app/src/components/actions/estimateRewards.js
+++ b/packages/react-app/src/components/actions/estimateRewards.js
@@ -1,0 +1,112 @@
+import React, { useState, useEffect } from 'react'
+import Web3 from "web3";
+
+import { Container, Row, Col } from 'react-bootstrap/';
+import { TypeOver, DataRow, Period, Slider, Grey, Blue, NuStakeAllocator, CircleQ, DisplayWei } from '@project/react-app/src/components'
+
+import { calcROI, MIN_STAKE, daysPerPeriod, getCurrentPeriod, formatWei, formatNumber } from '@project/react-app/src/constants'
+
+
+export const EstimateRewards = ({ setShow }) => {
+
+    const MIN_STAKE_BN = Web3.utils.toBN(Web3.utils.toWei(MIN_STAKE.toString(),  'ether'))
+
+    const [nuAllocated, setNuAllocation] = useState(MIN_STAKE_BN)
+    const [AllocationValid, setAllocationValid] = useState(true)
+    const [invalidMessage, setInvalidMessage] = useState()
+    const [duration, setDuration] = useState(daysPerPeriod * 10)
+    const [roi, setRoi] = useState({apr: 0, net: 0})
+    const [unlockDate, setUnlockDate] = useState(getCurrentPeriod() + 11)
+
+    const onAmountChanged = (amount) => {
+        // amount in wei
+        if (!amount) return
+
+        const amount_bn = Web3.utils.toBN(amount)
+        const rules = [
+            {
+                rule: amount_bn.gte(MIN_STAKE_BN),
+                message: `Amount ${formatWei(amount)} is less than the minimum 15,000 NU.`
+            }
+        ]
+
+        let message = null
+        if (rules.every((r)=>{
+            message=r.message
+            return r.rule
+        })){
+            setNuAllocation(amount)
+            setAllocationValid(true)
+            if (amount && duration){
+                setRoi(calcROI(amount, duration))
+            }
+        } else {
+            // setNuAllocation(0)
+            setAllocationValid(false)
+            setInvalidMessage(message)
+        }
+    }
+
+    const onDurationChanged = (duration) => {
+        if (duration < daysPerPeriod * 4) return
+        setDuration(duration)
+        setUnlockDate(getCurrentPeriod() + duration/daysPerPeriod + 2)
+        if (nuAllocated && duration){
+            setRoi(calcROI(nuAllocated, duration))
+        }
+    }
+
+    useEffect(() => {
+        if (nuAllocated && duration){
+            setRoi(calcROI(nuAllocated, duration))
+        }
+    }, [duration, AllocationValid, nuAllocated])
+
+    return(
+        <Container>
+            <div>
+
+            <Row noGutters className="d-flex justify-content-center">
+                <Col xs={12} className="d-flex justify-content-center">
+                    <NuStakeAllocator valid={AllocationValid} invalidmessage={invalidMessage} value={nuAllocated} onChange={onAmountChanged}/>
+                </Col>
+            </Row>
+            <Row>
+                <Col className="mr-4 ml-3">
+                    <div className="d-flex justify-content-between">
+                        <Grey>Duration</Grey>
+                        <strong><TypeOver onChange={onDurationChanged}>{duration}</TypeOver> <Grey>Days</Grey></strong>
+                    </div>
+                    <Slider step={daysPerPeriod} min={daysPerPeriod} max={daysPerPeriod * 365/daysPerPeriod} value={duration} onChange={onDurationChanged} />
+                </Col>
+            </Row>
+            <Row noGutters className="d-flex justify-content-center mt-3">
+                <Col xs={6} className="d-flex justify-content-between">
+                    <h5 className="nowrap mr-3">Estimated ROI</h5>
+                    <strong className="nowrap">
+                        <Blue>
+                            {formatNumber(roi.apr, 2)} % (APR)
+                            <CircleQ>Estimate based on duration of stake and current network participation</CircleQ>
+                        </Blue>
+                        <br/><Grey>{formatNumber(roi.net, 0)} NU</Grey>
+                    </strong>
+                    <br></br>
+                </Col>
+                <Col xs={8}><p><small><i>This is an estimate based on a rough extrapolation of historical data.  Please DYOR and assume that future results may vary.</i></small></p></Col>
+            </Row>
+            <Row className="mt-3">
+                <Col>
+                    <DataRow>
+                        <strong>Stake Amount</strong>
+                        <strong>Unlock Date <small><CircleQ>Unlock date only applicable if "wind down" is turned on (you can toggle that at /manage).</CircleQ></small></strong>
+                    </DataRow>
+                    <DataRow>
+                        {nuAllocated ? <h5><Blue><DisplayWei>{nuAllocated}</DisplayWei></Blue></h5>:''}
+                        <h5><Blue><Period>{unlockDate}</Period></Blue></h5>
+                    </DataRow>
+                </Col>
+            </Row>
+            </div>
+        </Container>
+    )
+}

--- a/packages/react-app/src/components/actions/modalActions.js
+++ b/packages/react-app/src/components/actions/modalActions.js
@@ -1,6 +1,7 @@
 export { Migrate } from '@project/react-app/src/components/actions/migrate'
 export { BondWorker } from '@project/react-app/src/components/actions/bondWorker'
 export { CreateStake } from '@project/react-app/src/components/actions/createStake'
+export { EstimateRewards } from '@project/react-app/src/components/actions/estimateRewards'
 export { DivideStake } from '@project/react-app/src/components/actions/divideStake'
 export { MergeStakes } from '@project/react-app/src/components/actions/mergeStakes'
 export { ExtendStake } from '@project/react-app/src/components/actions/extendStake'

--- a/packages/react-app/src/components/nuComponents.js
+++ b/packages/react-app/src/components/nuComponents.js
@@ -1,20 +1,15 @@
 import React from 'react'
 import moment from 'moment'
 import { useState, useEffect, useContext } from 'react';
-
+import Web3 from "web3";
 import { Context } from '@project/react-app/src/services'
-
-
 import { Form, Button, Row, Col, Container, Tooltip, OverlayTrigger} from 'react-bootstrap/';
-
 import { Grey, Blue, Input, DateSpan, DisplayWei} from '@project/react-app/src/components'
 import { millisecondsPerPeriod } from '@project/react-app/src/constants'
 
-
-
 export const NuBalance = (props) => {
     const context = useContext(Context)
-    const {provider, account, contracts } = context.wallet
+    const { provider, account, contracts } = context.wallet
 
     useEffect(() => {
         if (!props.balance && props.onBalance){
@@ -49,18 +44,15 @@ function NuCLickDisplay (props) {
 
 export const NuStakeAllocator = (props) => {
 
-    const context = useContext(Context)
-    const {web3} = context.wallet
-
     const [NUBalance, setNUBalance] = useState(props.initial || null)
     const [localValue, setLocalValue] = useState(props.value ? props.value : '')
 
-    const setValue = (value) => {
+    const setValue = value => {
         setLocalValue(value)
-        try{
-            // allow numbers, "-"" and "."
+        try {
+            // allow numbers, "-" and "."
             // don't allow ".."
-            props.onChange(web3.utils.toWei(value.replace(/[^0-9.]/g, '').replace(/\.{2,}/g, '.'),  'ether'))
+            props.onChange(Web3.utils.toWei(value.replace(/[^0-9.]/g, '').replace(/\.{2,}/g, '.'),  'ether'))
         } catch(err){
             console.error(err)
         }
@@ -69,23 +61,23 @@ export const NuStakeAllocator = (props) => {
     const handleNuBalance = (value) => {
         setNUBalance(value)
         if (props.onBalanceUpdate && value){
-            props.onBalanceUpdate(web3.utils.fromWei(value.toString(), 'ether'))
+            props.onBalanceUpdate(Web3.utils.fromWei(value.toString(), 'ether'))
         }
     }
 
     useEffect(()=>{
         const value = props.value || props.initial
-        setLocalValue(web3.utils.fromWei(value.toString(), 'ether'))
-    }, [])
+        setLocalValue(Web3.utils.fromWei(value.toString(), 'ether'))
+    }, [props.value, props.initial])
 
     return (
         <Container>
             <Row>
                 <Col>
-                    <div className="d-flex justify-content-between">
+                    { props.initial ? <div className="d-flex justify-content-between">
                         <Grey>Stake</Grey>
-                        <NuCLickDisplay onClick={(e) => setValue(web3.utils.fromWei(NUBalance.toString(), 'ether'))} balance={NUBalance} onBalance={handleNuBalance}/>
-                    </div>
+                        <NuCLickDisplay onClick={(e) => setValue(Web3.utils.fromWei(NUBalance.toString(), 'ether'))} balance={NUBalance} onBalance={handleNuBalance}/>
+                    </div> : '' }
                 </Col>
             </Row>
             <Row>
@@ -93,7 +85,7 @@ export const NuStakeAllocator = (props) => {
                     <Form.Control
                         as={Input}
                         onChange={(e) => setValue(e.target.value)}
-                        isInvalid={props.valid === false }
+                        isInvalid={props.valid === false}
                         type="text"
                         value={localValue}
                     />

--- a/packages/react-app/src/pages/manage/new/nodeProviders/selfHosted.js
+++ b/packages/react-app/src/pages/manage/new/nodeProviders/selfHosted.js
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react'
-import {Badge, Card, Col, Container, Form, Row} from 'react-bootstrap/';
+import {Badge, Card, Col, Container, Form, Row } from 'react-bootstrap/';
 import {InputBox, PrimaryButton, WorkerETHAddressField} from '../../../../components'
 import {Link} from 'react-router-dom'
 import { Context } from '@project/react-app/src/services'
@@ -16,6 +16,9 @@ export default (props) => {
         setCanContinue(account && props.workerAddress)
     }, [account, props.workerAddress])
 
+    const handleEstimateRewards = () => {
+        context.modals.triggerModal({message: "Estimate Rewards", component: "EstimateRewards"})
+    }
 
     return (
         <Container>
@@ -35,6 +38,8 @@ export default (props) => {
                             <h3><Badge variant="secondary">.1 ETH/mo</Badge></h3>
                         </Card.Body>
                     </Card>
+                    <h4>Estimated ROI</h4>
+                    <PrimaryButton small onClick={handleEstimateRewards}>Estimate Rewards</PrimaryButton>
                 </Col>
             </Row>
             <Row className="d-flex justify-content-center mt-5 mb-2">


### PR DESCRIPTION
Currently, accessing the rewards calculator is only possible by going through the steps of creating a stake, and in the event the user has no available NU or less than the 15k min, the calculator won't return a value. Therefor I added the same calculator within the Create Worker view less the requirement to connect a wallet and verify a token balance.
![Screen Shot 2021-09-10 at 1 30 03 PM](https://user-images.githubusercontent.com/59294937/132914146-c581b953-b9b7-4734-9223-5fdfd33adbb5.png)
